### PR TITLE
feat: use textures

### DIFF
--- a/Game/Shaders/default.hlsl
+++ b/Game/Shaders/default.hlsl
@@ -1,37 +1,48 @@
+// ------------- VERTEX SHADER ----------------------
+
 struct ModelViewProjection
 {
-    matrix MVP;
+    matrix model;
+    matrix view;
+    matrix projection;
 };
-ConstantBuffer<ModelViewProjection> myCB1 : register(b0);
+ConstantBuffer<ModelViewProjection> myCB0 : register(b0);
 
-struct VertexPosColor
+struct VS_INPUT
 {
-    float3 Position : POSITION;
-    float4 Color    : COLOR;
-};
-
-struct VertexShaderOutput
-{
-    float4 Color    : COLOR;
-    float4 Position : SV_Position;
+    float3 position : POSITION;
+    float2 texCoord : TEXCOORD;
 };
 
-VertexShaderOutput VSmain(VertexPosColor IN)
+struct VS_OUTPUT
 {
-    VertexShaderOutput OUT;
+    float4 position : SV_Position;
+    float2 texCoord : TEXCOORD;
+};
 
-    OUT.Position = mul(myCB1.MVP, float4(IN.Position, 1.0f));
-    OUT.Color = IN.Color;
+VS_OUTPUT VSmain(VS_INPUT input)
+{
+    VS_OUTPUT OUT;
+    float4 position = float4(input.position, 1.0f);
+    matrix mvp = mul(myCB0.model, mul(myCB0.view, myCB0.projection));
+    OUT.position = mul(position, mvp);
+    OUT.texCoord = input.texCoord;
 
     return OUT;
 }
 
-struct PixelShaderInput
+// ------------- PIXEL SHADER ----------------------
+
+Texture2D t1 : register(t0);
+SamplerState s1 : register(s0);
+
+struct PS_INPUT
 {
-    float4 Color : COLOR;
+    float4 position : SV_POSITION;
+    float2 texCoord : TEXCOORD;
 };
 
-float4 PSmain(PixelShaderInput IN) : SV_Target
+float4 PSmain(PS_INPUT input) : SV_Target
 {
-    return IN.Color;
+    return t1.Sample(s1, input.texCoord);
 }

--- a/Source/ChironEngine/ChironEngine.vcxproj
+++ b/Source/ChironEngine/ChironEngine.vcxproj
@@ -20,6 +20,7 @@
     <ClCompile Include="Source\DataModels\DX12\DescriptorAllocator\DescriptorAllocatorPage.cpp" />
     <ClCompile Include="Source\DataModels\DX12\DynamicDescriptorHeap\DynamicDescriptorHeap.cpp" />
     <ClCompile Include="Source\DataModels\DX12\ResourceStateTracker\ResourceStateTracker.cpp" />
+    <ClCompile Include="Source\DataModels\DX12\Resource\IndexBuffer.cpp" />
     <ClCompile Include="Source\DataModels\DX12\Resource\Resource.cpp" />
     <ClCompile Include="Source\DataModels\DX12\Resource\Texture.cpp" />
     <ClCompile Include="Source\DataModels\DX12\RootSignature\RootSignature.cpp" />
@@ -47,6 +48,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="Source\DataModels\DX12\Resource\VertexBuffer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Application.h" />
@@ -61,6 +63,7 @@
     <ClInclude Include="Source\DataModels\DX12\DescriptorAllocator\DescriptorAllocatorPage.h" />
     <ClInclude Include="Source\DataModels\DX12\DynamicDescriptorHeap\DynamicDescriptorHeap.h" />
     <ClInclude Include="Source\DataModels\DX12\ResourceStateTracker\ResourceStateTracker.h" />
+    <ClInclude Include="Source\DataModels\DX12\Resource\IndexBuffer.h" />
     <ClInclude Include="Source\DataModels\DX12\Resource\Resource.h" />
     <ClInclude Include="Source\DataModels\DX12\Resource\Texture.h" />
     <ClInclude Include="Source\DataModels\DX12\RootSignature\RootSignature.h" />
@@ -87,6 +90,7 @@
     <ClInclude Include="Source\Modules\ModuleProgram.h" />
     <ClInclude Include="Source\Modules\ModuleWindow.h" />
     <ClInclude Include="Source\Pch.h" />
+    <ClInclude Include="Source\DataModels\DX12\Resource\VertexBuffer.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>

--- a/Source/ChironEngine/ChironEngine.vcxproj.filters
+++ b/Source/ChironEngine/ChironEngine.vcxproj.filters
@@ -147,6 +147,12 @@
     <ClCompile Include="Source\DataModels\Programs\GenerateMipsProgram.cpp">
       <Filter>Source\DataModels\Programs</Filter>
     </ClCompile>
+    <ClCompile Include="Source\DataModels\DX12\Resource\VertexBuffer.cpp">
+      <Filter>Source\DataModels\DX12\Resources</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\DataModels\DX12\Resource\IndexBuffer.cpp">
+      <Filter>Source\DataModels\DX12\Resources</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Application.h">
@@ -257,6 +263,12 @@
     </ClInclude>
     <ClInclude Include="Source\DataModels\Programs\GenerateMipsProgram.h">
       <Filter>Source\DataModels\Programs</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\DataModels\DX12\Resource\VertexBuffer.h">
+      <Filter>Source\DataModels\DX12\Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\DataModels\DX12\Resource\IndexBuffer.h">
+      <Filter>Source\DataModels\DX12\Resources</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Source/ChironEngine/Source/Auxiliar/Utils.cpp
+++ b/Source/ChironEngine/Source/Auxiliar/Utils.cpp
@@ -5,8 +5,23 @@ void Chiron::Utils::ThrowIfFailed(HRESULT hr, const std::string& message) noexce
 {
     if (FAILED(hr))
     {
-        throw std::runtime_error("Error: " + message + " (HRESULT: 0x" + std::to_string(hr) + ")");
+        LOG_ERROR("Error: " + GetErrorMessage(hr) + " (HRESULT: 0x" + std::to_string(hr) + ")");
+        throw std::runtime_error("");
     }
+}
+
+std::string Chiron::Utils::WStringToString(const std::wstring& wstr)
+{
+    // Get the buffer size
+    int bufferSize = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, nullptr, 0, nullptr, nullptr);
+
+    // Reserve space
+    std::string str(bufferSize, 0);
+
+    // Parse
+    WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, &str[0], bufferSize, nullptr, nullptr);
+
+    return str;
 }
 
 HANDLE Chiron::Utils::CreateEventHandle()
@@ -17,4 +32,32 @@ HANDLE Chiron::Utils::CreateEventHandle()
     assert(event && "Failed to create event.");
 
     return event;
+}
+
+std::string Chiron::Utils::GetErrorMessage(HRESULT hr)
+{
+    LPWSTR errorText = nullptr;
+
+    // Get the message
+    DWORD formatResult = FormatMessage(
+        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
+        nullptr, hr, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        (LPWSTR)&errorText, 0, nullptr);
+
+    std::string errorString;
+    if (formatResult > 0)
+    {
+        // Parse to string
+        std::wstring wErrorText(errorText);
+        errorString = WStringToString(wErrorText);
+
+        // Free memory
+        LocalFree(errorText);
+    }
+    else
+    {
+        errorString = "Unknown error";
+    }
+
+    return errorString;
 }

--- a/Source/ChironEngine/Source/Auxiliar/Utils.h
+++ b/Source/ChironEngine/Source/Auxiliar/Utils.h
@@ -15,6 +15,10 @@ namespace Chiron
         // Helper utility converts D3D API failures into exceptions.
         static void ThrowIfFailed(HRESULT hr, const std::string& message = "") noexcept(false);
 
+        // ------------- PARSE ----------------------
+
+        static std::string WStringToString(const std::wstring& wstr);
+
         // ------------- CONTAINERS ----------------------
 
         template<typename T>
@@ -81,6 +85,9 @@ namespace Chiron
 
         static inline const ddVec3& ddConvert(const DirectX::SimpleMath::Vector3& v);
         static inline const ddMat4x4& ddConvert(const DirectX::SimpleMath::Matrix& m);
+
+    private:
+        static std::string GetErrorMessage(HRESULT hr);
     };
 
     template<typename T>

--- a/Source/ChironEngine/Source/DataModels/DX12/CommandList/CommandList.cpp
+++ b/Source/ChironEngine/Source/DataModels/DX12/CommandList/CommandList.cpp
@@ -229,6 +229,16 @@ void CommandList::SetGraphics32BitConstants(uint32_t rootParameterIndex, uint32_
     _commandList->SetGraphicsRoot32BitConstants(rootParameterIndex, numConstants, constants, destOffsetIn32BitValues);
 }
 
+void CommandList::SetDescriptorHeaps(UINT numHeaps, ID3D12DescriptorHeap* descriptorHeaps[])
+{
+    _commandList->SetDescriptorHeaps(numHeaps, descriptorHeaps);
+}
+
+void CommandList::SetGraphicsRootDescriptorTable(UINT indexRootDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle)
+{
+    _commandList->SetGraphicsRootDescriptorTable(indexRootDescriptor, gpuDescriptorHandle);
+}
+
 void CommandList::UseProgram(Program* program)
 {
     ID3D12PipelineState* pipelineState = program->GetPipelineState();
@@ -319,7 +329,7 @@ void CommandList::SetShaderResourceView(uint32_t rootParameterIndex, uint32_t de
     }
 
     _dynamicDescriptorHeap[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]->StageDescriptors(rootParameterIndex, 
-        descriptorOffset, 1, texture->GetShaderResourceView());
+        descriptorOffset, 1, texture->GetShaderResourceView().GetCPUDescriptorHandle());
 
     TrackResource(texture);
 }
@@ -340,7 +350,7 @@ void CommandList::SetUnorderedAccessView(uint32_t rootParameterIndex, uint32_t d
     }
 
     _dynamicDescriptorHeap[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]->StageDescriptors(rootParameterIndex, descrptorOffset, 
-        1, texture->GetUnorderedAccessView(mips));
+        1, texture->GetUnorderedAccessView().GetCPUDescriptorHandle(mips));
 
     TrackResource(texture);
 }

--- a/Source/ChironEngine/Source/DataModels/DX12/CommandList/CommandList.cpp
+++ b/Source/ChironEngine/Source/DataModels/DX12/CommandList/CommandList.cpp
@@ -157,21 +157,21 @@ void CommandList::CopyResource(const Resource* dstRes, const Resource* srcRes)
     CopyResource(dstRes->GetResource(), srcRes->GetResource());
 }
 
-void CommandList::CopyTextureSubresource(const std::shared_ptr<Texture>& texture, uint32_t firstSubresource, 
+void CommandList::UpdateBufferResource(const std::shared_ptr<Resource>& resource, uint32_t firstSubresource, 
     uint32_t numSubresources, D3D12_SUBRESOURCE_DATA* subresourceData)
 {
-    assert(texture);
+    assert(resource);
+    assert(numSubresources > 0);
 
-    auto destinationResource = texture->GetResource();
+    auto destinationResource = resource->GetResource();
 
     if (destinationResource)
     {
         auto device = App->GetModule<ModuleID3D12>()->GetDevice();
 
         // Resource must be in the copy-destination state.
-        TransitionBarrier(texture.get(), D3D12_RESOURCE_STATE_COPY_DEST);
-        FlushResourceBarriers();
-
+        TransitionBarrier(resource.get(), D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, true);
+        
         UINT64 requiredSize = GetRequiredIntermediateSize(destinationResource, firstSubresource, numSubresources);
 
         // Create a temporary (intermediate) resource for uploading the subresources
@@ -187,7 +187,7 @@ void CommandList::CopyTextureSubresource(const std::shared_ptr<Texture>& texture
             numSubresources, subresourceData);
 
         TrackResource(intermediateResource.Get());
-        TrackResource(texture.get());
+        TrackResource(resource.get());
     }
 }
 void CommandList::SetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY primitiveTopology)

--- a/Source/ChironEngine/Source/DataModels/DX12/CommandList/CommandList.h
+++ b/Source/ChironEngine/Source/DataModels/DX12/CommandList/CommandList.h
@@ -71,6 +71,8 @@ public:
         BOOL RTsSingleHandleToDescriptorRange, const D3D12_CPU_DESCRIPTOR_HANDLE* pDepthStencilDescriptor);
     void SetGraphics32BitConstants(uint32_t rootParameterIndex, uint32_t numConstants, const void* constants, 
         UINT destOffsetIn32BitValues = 0);
+    void SetDescriptorHeaps(UINT numHeaps, ID3D12DescriptorHeap* descriptorHeaps[]);
+    void SetGraphicsRootDescriptorTable(UINT indexRootDescriptor, D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle);
     void UseProgram(Program* program);
 
     void Draw(uint32_t vertexCount, uint32_t instanceCount = 1, uint32_t startVertex = 0, uint32_t startInstance = 0);

--- a/Source/ChironEngine/Source/DataModels/DX12/CommandList/CommandList.h
+++ b/Source/ChironEngine/Source/DataModels/DX12/CommandList/CommandList.h
@@ -59,7 +59,7 @@ public:
 
     void CopyResource(ID3D12Resource* dstRes, ID3D12Resource* srcRes);
     void CopyResource(const Resource* dstRes, const Resource* srcRes);
-    void CopyTextureSubresource(const std::shared_ptr<Texture>& texture, uint32_t firstSubresource,
+    void UpdateBufferResource(const std::shared_ptr<Resource>& texture, uint32_t firstSubresource,
         uint32_t numSubresources, D3D12_SUBRESOURCE_DATA* subresourceData);
 
     void SetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY primitiveTopology);
@@ -135,10 +135,7 @@ private:
     ComPtr<ID3D12GraphicsCommandList2> _commandList;
     ComPtr<ID3D12CommandAllocator> _commandAllocator;
 
-    // For copy queues, it may be necessary to generate mips while loading textures.
-    // Mips can't be generated on copy queues but must be generated on compute or
-    // direct queues. In this case, a Compute command list is generated and executed 
-    // after the copy queue is finished uploading the first sub resource.
+    // For copy queues in case a compute operation is needed.
     std::shared_ptr<CommandList> _computeCommandList;
 
     // Currently bound root signature.

--- a/Source/ChironEngine/Source/DataModels/DX12/DescriptorAllocator/DescriptorAllocation.cpp
+++ b/Source/ChironEngine/Source/DataModels/DX12/DescriptorAllocator/DescriptorAllocation.cpp
@@ -5,12 +5,14 @@
 
 #include "DescriptorAllocatorPage.h"
 
-DescriptorAllocation::DescriptorAllocation() : _descriptorHandle{ 0 }, _numHandles(0), _descriptorSize(0), _page(nullptr)
+DescriptorAllocation::DescriptorAllocation() : _cpuDescriptorHandle{ 0 }, _gpuDescriptorHandle{ 0 }, _numHandles(0), 
+_descriptorSize(0), _page(nullptr)
 {
 }
 
-DescriptorAllocation::DescriptorAllocation(D3D12_CPU_DESCRIPTOR_HANDLE descriptor, uint32_t numHandles, 
-	uint32_t descriptorSize, std::shared_ptr<DescriptorAllocatorPage> page) : _descriptorHandle(descriptor), 
+DescriptorAllocation::DescriptorAllocation(D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptor, 
+	CD3DX12_GPU_DESCRIPTOR_HANDLE gpuDescriptor, uint32_t numHandles, uint32_t descriptorSize, 
+	std::shared_ptr<DescriptorAllocatorPage> page) : _cpuDescriptorHandle(cpuDescriptor), _gpuDescriptorHandle(gpuDescriptor),
 	_numHandles(numHandles), _descriptorSize(descriptorSize), _page(page)
 {
 }
@@ -21,10 +23,11 @@ DescriptorAllocation::~DescriptorAllocation()
 }
 
 DescriptorAllocation::DescriptorAllocation(DescriptorAllocation&& allocation) noexcept : 
-	_descriptorHandle(allocation._descriptorHandle), _numHandles(allocation._numHandles), 
-	_descriptorSize(allocation._descriptorSize), _page(std::move(allocation._page))
+	_cpuDescriptorHandle(allocation._cpuDescriptorHandle), _gpuDescriptorHandle(allocation._gpuDescriptorHandle),
+	_numHandles(allocation._numHandles), _descriptorSize(allocation._descriptorSize), _page(std::move(allocation._page))
 {
-	allocation._descriptorHandle.ptr = 0;
+	allocation._cpuDescriptorHandle.ptr = 0;
+	allocation._gpuDescriptorHandle.ptr = 0;
 	allocation._numHandles = 0;
 	allocation._descriptorSize = 0;
 }
@@ -33,12 +36,14 @@ DescriptorAllocation& DescriptorAllocation::operator=(DescriptorAllocation&& oth
 {
 	Free();
 
-	_descriptorHandle = other._descriptorHandle;
+	_cpuDescriptorHandle = other._cpuDescriptorHandle;
+	_gpuDescriptorHandle = other._gpuDescriptorHandle;
 	_numHandles = other._numHandles;
 	_descriptorSize = other._descriptorSize;
 	_page = std::move(other._page);
 
-	other._descriptorHandle.ptr = 0;
+	other._cpuDescriptorHandle.ptr = 0;
+	other._gpuDescriptorHandle.ptr = 0;
 	other._numHandles = 0;
 	other._descriptorSize = 0;
 
@@ -47,7 +52,7 @@ DescriptorAllocation& DescriptorAllocation::operator=(DescriptorAllocation&& oth
 
 bool DescriptorAllocation::IsNull() const
 {
-	return _descriptorHandle.ptr == 0;
+	return _cpuDescriptorHandle.ptr == 0;
 }
 
 void DescriptorAllocation::Free()
@@ -56,7 +61,8 @@ void DescriptorAllocation::Free()
 	{
 		_page->Free(std::move(*this), App->GetFrameCount());
 
-		_descriptorHandle.ptr = 0;
+		_cpuDescriptorHandle.ptr = 0;
+		_gpuDescriptorHandle.ptr = 0;
 		_numHandles = 0;
 		_descriptorSize = 0;
 		_page.reset();

--- a/Source/ChironEngine/Source/DataModels/DX12/DescriptorAllocator/DescriptorAllocation.h
+++ b/Source/ChironEngine/Source/DataModels/DX12/DescriptorAllocator/DescriptorAllocation.h
@@ -7,8 +7,8 @@ class DescriptorAllocation
 public:
     DescriptorAllocation();
 
-    DescriptorAllocation(D3D12_CPU_DESCRIPTOR_HANDLE descriptor, uint32_t numHandles, uint32_t descriptorSize, 
-        std::shared_ptr<DescriptorAllocatorPage> page);
+    DescriptorAllocation(D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptor, CD3DX12_GPU_DESCRIPTOR_HANDLE gpuDescriptor,
+        uint32_t numHandles, uint32_t descriptorSize, std::shared_ptr<DescriptorAllocatorPage> page);
 
     // The destructor will automatically free the allocation.
     ~DescriptorAllocation();
@@ -25,19 +25,22 @@ public:
 
     // ------------- GETTERS ----------------------
 
-    // Get a descriptor at a particular offset in the allocation.
-    inline D3D12_CPU_DESCRIPTOR_HANDLE GetDescriptorHandle(uint32_t offset = 0) const;
+    // Get a CPU descriptor at a particular offset in the allocation.
+    inline D3D12_CPU_DESCRIPTOR_HANDLE GetCPUDescriptorHandle(uint32_t offset = 0) const;
+    // Get a GPU descriptor at a particular offset in the allocation.
+    inline D3D12_GPU_DESCRIPTOR_HANDLE GetGPUDescriptorHandle(uint32_t offset = 0) const;
 
     inline uint32_t GetNumHandles() const;
 
-    inline std::shared_ptr<DescriptorAllocatorPage> GetDescriptorAllocatorPage() const;
+    inline DescriptorAllocatorPage* GetDescriptorAllocatorPage() const;
 
 private:
     // Free the descriptor back to the heap it came from.
     void Free();
 
 private:
-    D3D12_CPU_DESCRIPTOR_HANDLE _descriptorHandle;
+    D3D12_CPU_DESCRIPTOR_HANDLE _cpuDescriptorHandle;
+    D3D12_GPU_DESCRIPTOR_HANDLE _gpuDescriptorHandle;
     uint32_t _numHandles;
     uint32_t _descriptorSize;
 
@@ -45,10 +48,16 @@ private:
     std::shared_ptr<DescriptorAllocatorPage> _page;
 };
 
-inline D3D12_CPU_DESCRIPTOR_HANDLE DescriptorAllocation::GetDescriptorHandle(uint32_t offset) const
+inline D3D12_CPU_DESCRIPTOR_HANDLE DescriptorAllocation::GetCPUDescriptorHandle(uint32_t offset) const
 {
     assert(offset < _numHandles);
-    return CD3DX12_CPU_DESCRIPTOR_HANDLE(_descriptorHandle, offset, _descriptorSize);
+    return CD3DX12_CPU_DESCRIPTOR_HANDLE(_cpuDescriptorHandle, offset, _descriptorSize);
+}
+
+inline D3D12_GPU_DESCRIPTOR_HANDLE DescriptorAllocation::GetGPUDescriptorHandle(uint32_t offset) const
+{
+    assert(offset < _numHandles);
+    return CD3DX12_GPU_DESCRIPTOR_HANDLE(_gpuDescriptorHandle, offset, _descriptorSize);
 }
 
 inline uint32_t DescriptorAllocation::GetNumHandles() const
@@ -56,7 +65,7 @@ inline uint32_t DescriptorAllocation::GetNumHandles() const
     return _numHandles;
 }
 
-inline std::shared_ptr<DescriptorAllocatorPage> DescriptorAllocation::GetDescriptorAllocatorPage() const
+inline DescriptorAllocatorPage* DescriptorAllocation::GetDescriptorAllocatorPage() const
 {
-    return _page;
+    return _page.get();
 }

--- a/Source/ChironEngine/Source/DataModels/DX12/DescriptorAllocator/DescriptorAllocatorPage.h
+++ b/Source/ChironEngine/Source/DataModels/DX12/DescriptorAllocator/DescriptorAllocatorPage.h
@@ -22,6 +22,7 @@ public:
     // ------------- GETTERS ----------------------
 
     inline std::shared_ptr<DescriptorAllocatorPage> GetSharedPtr();
+    inline ComPtr<ID3D12DescriptorHeap> GetDescriptorHeap() const;
     inline D3D12_DESCRIPTOR_HEAP_TYPE GetHeapType() const;
     uint32_t NumFreeHandles() const;
 
@@ -79,7 +80,8 @@ private:
     // ------------- DESCRIPTOR INFO ----------------------
 
     ComPtr<ID3D12DescriptorHeap> _descriptorHeap;
-    CD3DX12_CPU_DESCRIPTOR_HANDLE _baseDescriptor;
+    CD3DX12_CPU_DESCRIPTOR_HANDLE _baseCPUDescriptor;
+    CD3DX12_GPU_DESCRIPTOR_HANDLE _baseGPUDescriptor;
     D3D12_DESCRIPTOR_HEAP_TYPE _heapType;
     uint32_t _descriptorSize;
 
@@ -94,6 +96,11 @@ private:
 inline std::shared_ptr<DescriptorAllocatorPage> DescriptorAllocatorPage::GetSharedPtr()
 {
     return shared_from_this();
+}
+
+inline ComPtr<ID3D12DescriptorHeap> DescriptorAllocatorPage::GetDescriptorHeap() const
+{
+    return _descriptorHeap;
 }
 
 inline D3D12_DESCRIPTOR_HEAP_TYPE DescriptorAllocatorPage::GetHeapType() const

--- a/Source/ChironEngine/Source/DataModels/DX12/Resource/IndexBuffer.cpp
+++ b/Source/ChironEngine/Source/DataModels/DX12/Resource/IndexBuffer.cpp
@@ -1,0 +1,21 @@
+#include "Pch.h"
+#include "IndexBuffer.h"
+
+IndexBuffer::IndexBuffer(const D3D12_RESOURCE_DESC& resourceDesc, size_t numIndices, const DXGI_FORMAT& indexFormat, 
+	const std::wstring& name, const D3D12_CLEAR_VALUE* clearValue) : Resource(resourceDesc, name, clearValue),
+	_numIndices(numIndices), _format(indexFormat)
+{
+	int stride = _format == DXGI_FORMAT_R32_UINT ? 4 : 2;
+	_indexBufferView.BufferLocation = _resource->GetGPUVirtualAddress();
+	_indexBufferView.SizeInBytes = static_cast<UINT>(numIndices * stride);
+	_indexBufferView.Format = indexFormat;
+}
+
+IndexBuffer::IndexBuffer(const IndexBuffer& copy) : Resource(copy), _numIndices(copy._numIndices), _format(copy._format), 
+_indexBufferView(copy._indexBufferView)
+{
+}
+
+IndexBuffer::~IndexBuffer()
+{
+}

--- a/Source/ChironEngine/Source/DataModels/DX12/Resource/IndexBuffer.h
+++ b/Source/ChironEngine/Source/DataModels/DX12/Resource/IndexBuffer.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "Resource.h"
+
+class IndexBuffer : public Resource
+{
+public:
+	IndexBuffer() = delete;
+	IndexBuffer(const D3D12_RESOURCE_DESC& resourceDesc, size_t numIndices, const DXGI_FORMAT& indexFormat,
+		const std::wstring& name = L"", const D3D12_CLEAR_VALUE* clearValue = nullptr);
+	IndexBuffer(const IndexBuffer& copy);
+
+	~IndexBuffer() override;
+
+	// ------------- GETTERS ----------------------
+
+	inline const D3D12_INDEX_BUFFER_VIEW& GetIndexBufferView() const;
+
+private:
+	size_t _numIndices;
+	DXGI_FORMAT _format;
+	D3D12_INDEX_BUFFER_VIEW _indexBufferView;
+};
+
+inline const D3D12_INDEX_BUFFER_VIEW& IndexBuffer::GetIndexBufferView() const
+{
+	return _indexBufferView;
+}

--- a/Source/ChironEngine/Source/DataModels/DX12/Resource/Resource.cpp
+++ b/Source/ChironEngine/Source/DataModels/DX12/Resource/Resource.cpp
@@ -13,28 +13,33 @@ Resource::Resource() : _resource(nullptr), _name(L"")
 
 Resource::Resource(const D3D12_RESOURCE_DESC& resourceDesc, const std::wstring& name, const D3D12_CLEAR_VALUE* clearValue)
 {
-	auto device = App->GetModule<ModuleID3D12>()->GetDevice();
+	if (clearValue)
+	{
+		_clearValue = std::make_unique<D3D12_CLEAR_VALUE>(*clearValue);
+	}
 
+	auto device = App->GetModule<ModuleID3D12>()->GetDevice();
 	CD3DX12_HEAP_PROPERTIES heapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
 	Chiron::Utils::ThrowIfFailed(device->CreateCommittedResource(&heapProperties, D3D12_HEAP_FLAG_NONE, &resourceDesc,
-		D3D12_RESOURCE_STATE_COMMON, clearValue, IID_PPV_ARGS(&_resource)));
+		D3D12_RESOURCE_STATE_COMMON, _clearValue.get(), IID_PPV_ARGS(&_resource)));
 
-	_resource->SetName(_name.c_str());
-
+	SetName(name);
 	ResourceStateTracker::AddGlobalResourceState(_resource.Get(), D3D12_RESOURCE_STATE_COMMON);
-
 	CheckFeatureSupport();
 }
 
 Resource::Resource(ComPtr<ID3D12Resource> resource) : _resource(resource)
 {
 	ResourceStateTracker::AddGlobalResourceState(_resource.Get(), D3D12_RESOURCE_STATE_COMMON);
-	
 	CheckFeatureSupport();
 }
 
 Resource::Resource(const Resource& copy) : _resource(copy._resource), _name(copy._name), _featureSupport(copy._featureSupport)
 {
+	if (copy._clearValue)
+	{
+		_clearValue = std::make_unique<D3D12_CLEAR_VALUE>(*copy._clearValue);
+	}
 }
 
 Resource::~Resource()
@@ -42,30 +47,33 @@ Resource::~Resource()
 	ResourceStateTracker::RemoveGlobalResourceState(_resource.Get());
 }
 
-Resource& Resource::operator=(const Resource& other)
-{
-	if (&other != this)
-	{
-		_resource = other._resource;
-		_name = other._name;
-		_featureSupport = other._featureSupport;
-	}
-	return *this;
-}
-
-Resource& Resource::operator=(Resource&& other) noexcept
-{
-	if (&other != this)
-	{
-		_resource = other._resource;
-		_name = other._name;
-		_featureSupport = other._featureSupport;
-
-		other._resource.Reset();
-		other._name.clear();
-	}
-	return *this;
-}
+//Resource& Resource::operator=(const Resource& other)
+//{
+//	if (&other != this)
+//	{
+//		D3D12_RESOURCE_DESC resourceDesc = other._resource->GetDesc();
+//		CreateCommittedResource(resourceDesc);
+//		SetName(other._name);
+//		_featureSupport = other._featureSupport;
+//		_clearValue = std::make_unique<D3D12_CLEAR_VALUE>(other._clearValue);
+//	}
+//	return *this;
+//}
+//
+//Resource& Resource::operator=(Resource&& other) noexcept
+//{
+//	if (&other != this)
+//	{
+//		D3D12_RESOURCE_DESC resourceDesc = other._resource->GetDesc();
+//		CreateCommittedResource(resourceDesc);
+//		SetName(other._name);
+//		_featureSupport = other._featureSupport;
+//		_clearValue = std::make_unique<D3D12_CLEAR_VALUE>(other._clearValue);
+//
+//		other.Reset();
+//	}
+//	return *this;
+//}
 
 void Resource::Reset()
 {

--- a/Source/ChironEngine/Source/DataModels/DX12/Resource/Resource.cpp
+++ b/Source/ChironEngine/Source/DataModels/DX12/Resource/Resource.cpp
@@ -26,7 +26,7 @@ Resource::Resource(const D3D12_RESOURCE_DESC& resourceDesc, const std::wstring& 
 	CheckFeatureSupport();
 }
 
-Resource::Resource(ComPtr<ID3D12Resource> resource, const std::wstring& name) : _resource(resource), _name(name)
+Resource::Resource(ComPtr<ID3D12Resource> resource) : _resource(resource)
 {
 	ResourceStateTracker::AddGlobalResourceState(_resource.Get(), D3D12_RESOURCE_STATE_COMMON);
 	

--- a/Source/ChironEngine/Source/DataModels/DX12/Resource/Resource.h
+++ b/Source/ChironEngine/Source/DataModels/DX12/Resource/Resource.h
@@ -3,14 +3,6 @@
 class Resource
 {
 public:
-	Resource();
-	Resource(const D3D12_RESOURCE_DESC& resourceDesc, const std::wstring& name = L"", 
-		const D3D12_CLEAR_VALUE* clearValue = nullptr);
-	Resource(ComPtr<ID3D12Resource> resource, const std::wstring& name = L"");
-	Resource(const Resource& copy);
-	
-	virtual ~Resource();
-
 	Resource& operator=(const Resource& other);
 	Resource& operator=(Resource&& other) noexcept;
 
@@ -35,6 +27,15 @@ public:
 
 	void SetResource(ComPtr<ID3D12Resource> resource);
 	inline void SetName(std::wstring name);
+
+protected:
+	Resource();
+	Resource(const D3D12_RESOURCE_DESC& resourceDesc, const std::wstring& name = L"",
+		const D3D12_CLEAR_VALUE* clearValue = nullptr);
+	Resource(ComPtr<ID3D12Resource> resource);
+	Resource(const Resource& copy);
+
+	virtual ~Resource();
 
 private:
 	void CheckFeatureSupport();

--- a/Source/ChironEngine/Source/DataModels/DX12/Resource/Resource.h
+++ b/Source/ChironEngine/Source/DataModels/DX12/Resource/Resource.h
@@ -3,9 +3,6 @@
 class Resource
 {
 public:
-	Resource& operator=(const Resource& other);
-	Resource& operator=(Resource&& other) noexcept;
-
 	inline bool IsValid();
 
 	void Reset();
@@ -18,10 +15,10 @@ public:
 	inline ID3D12Resource* GetResource() const;
 	inline const std::wstring& GetName() const;
 
-	virtual D3D12_CPU_DESCRIPTOR_HANDLE GetRenderTargetView() const = 0;
-	virtual D3D12_CPU_DESCRIPTOR_HANDLE GetDepthStencilView() const = 0;
-	virtual D3D12_CPU_DESCRIPTOR_HANDLE GetShaderResourceView() const = 0;
-	virtual D3D12_CPU_DESCRIPTOR_HANDLE GetUnorderedAccessView(uint32_t mips) const = 0;
+	/*virtual D3D12_CPU_DESCRIPTOR_HANDLE GetCPURenderTargetView() const = 0;
+	virtual D3D12_CPU_DESCRIPTOR_HANDLE GetCPUDepthStencilView() const = 0;
+	virtual D3D12_CPU_DESCRIPTOR_HANDLE GetCPUShaderResourceView(uint32_t mips = 0) const = 0;
+	virtual D3D12_CPU_DESCRIPTOR_HANDLE GetCPUUnorderedAccessView(uint32_t mips = 0) const = 0;*/
 
 	// ------------- SETTERS ----------------------
 
@@ -37,6 +34,9 @@ protected:
 
 	virtual ~Resource();
 
+	Resource& operator=(const Resource& other) = delete;
+	Resource& operator=(Resource&& other) = delete;
+
 private:
 	void CheckFeatureSupport();
 
@@ -45,6 +45,7 @@ protected:
 	std::wstring _name;
 private:
 	D3D12_FEATURE_DATA_FORMAT_SUPPORT _featureSupport;
+	std::unique_ptr<D3D12_CLEAR_VALUE> _clearValue;
 };
 
 inline bool Resource::IsValid()

--- a/Source/ChironEngine/Source/DataModels/DX12/Resource/Texture.cpp
+++ b/Source/ChironEngine/Source/DataModels/DX12/Resource/Texture.cpp
@@ -17,7 +17,7 @@ Texture::Texture(const D3D12_RESOURCE_DESC& resourceDesc, const std::wstring& na
 	CreateViews();
 }
 
-Texture::Texture(ComPtr<ID3D12Resource> resource, const std::wstring& name) : Resource(resource, name)
+Texture::Texture(ComPtr<ID3D12Resource> resource) : Resource(resource)
 {
 	CreateViews();
 }

--- a/Source/ChironEngine/Source/DataModels/DX12/Resource/Texture.h
+++ b/Source/ChironEngine/Source/DataModels/DX12/Resource/Texture.h
@@ -21,7 +21,7 @@ public:
 	Texture();
 	Texture(const D3D12_RESOURCE_DESC& resourceDesc, const std::wstring& name = L"", 
 		const D3D12_CLEAR_VALUE* clearValue = nullptr);
-	Texture(ComPtr<ID3D12Resource> resource, const std::wstring& name = L"");
+	Texture(ComPtr<ID3D12Resource> resource);
 	Texture(const Texture& copy);
 
 	~Texture() override;

--- a/Source/ChironEngine/Source/DataModels/DX12/Resource/Texture.h
+++ b/Source/ChironEngine/Source/DataModels/DX12/Resource/Texture.h
@@ -26,8 +26,8 @@ public:
 
 	~Texture() override;
 
-	Texture& operator=(const Texture& other);
-	Texture& operator=(Texture&& other) noexcept;
+	Texture& operator=(const Texture& other) = delete;
+	Texture& operator=(Texture&& other) = delete;
 
 	void Resize(uint32_t width, uint32_t height, uint32_t depthOrArraySize = 1);
 
@@ -44,10 +44,16 @@ public:
 
 	// ------------- GETTERS ----------------------
 
-	inline D3D12_CPU_DESCRIPTOR_HANDLE GetRenderTargetView() const override;
-	inline D3D12_CPU_DESCRIPTOR_HANDLE GetDepthStencilView() const override;
-	inline D3D12_CPU_DESCRIPTOR_HANDLE GetShaderResourceView() const override;
-	inline D3D12_CPU_DESCRIPTOR_HANDLE GetUnorderedAccessView(uint32_t mips) const override;
+	/*inline D3D12_CPU_DESCRIPTOR_HANDLE GetCPURenderTargetView() const override;
+	inline D3D12_CPU_DESCRIPTOR_HANDLE GetCPUDepthStencilView() const override;
+	inline D3D12_CPU_DESCRIPTOR_HANDLE GetCPUShaderResourceView(uint32_t mips) const override;
+	inline D3D12_CPU_DESCRIPTOR_HANDLE GetCPUUnorderedAccessView(uint32_t mips) const override;*/
+	
+	inline const DescriptorAllocation& GetRenderTargetView() const;
+	inline const DescriptorAllocation& GetDepthStencilView() const;
+	inline const DescriptorAllocation& GetShaderResourceView() const;
+	inline const DescriptorAllocation& GetUnorderedAccessView() const;
+
 	inline TextureType GetTextureType() const;
 
 	// ------------- SETTERS ----------------------
@@ -131,24 +137,44 @@ inline bool Texture::IsSRGBFormat(DXGI_FORMAT format)
 	return false;
 }
 
-inline D3D12_CPU_DESCRIPTOR_HANDLE Texture::GetRenderTargetView() const
+//inline D3D12_CPU_DESCRIPTOR_HANDLE Texture::GetCPURenderTargetView() const
+//{
+//	return _renderTargetView.GetCPUDescriptorHandle();
+//}
+//
+//inline D3D12_CPU_DESCRIPTOR_HANDLE Texture::GetCPUDepthStencilView() const
+//{
+//	return _depthStencilView.GetCPUDescriptorHandle();
+//}
+//
+//inline D3D12_CPU_DESCRIPTOR_HANDLE Texture::GetCPUShaderResourceView(uint32_t mips) const
+//{
+//	return _shaderResourceView.GetCPUDescriptorHandle(mips);
+//}
+//
+//inline D3D12_CPU_DESCRIPTOR_HANDLE Texture::GetCPUUnorderedAccessView(uint32_t mips) const
+//{
+//	return _unorderedAccessView.GetCPUDescriptorHandle(mips);
+//}
+
+inline const DescriptorAllocation& Texture::GetRenderTargetView() const
 {
-	return _renderTargetView.GetDescriptorHandle();
+	return _renderTargetView;
 }
 
-inline D3D12_CPU_DESCRIPTOR_HANDLE Texture::GetDepthStencilView() const
+inline const DescriptorAllocation& Texture::GetDepthStencilView() const
 {
-	return _depthStencilView.GetDescriptorHandle();
+	return _depthStencilView;
 }
 
-inline D3D12_CPU_DESCRIPTOR_HANDLE Texture::GetShaderResourceView() const
+inline const DescriptorAllocation& Texture::GetShaderResourceView() const
 {
-	return _shaderResourceView.GetDescriptorHandle();
+	return _shaderResourceView;
 }
 
-inline D3D12_CPU_DESCRIPTOR_HANDLE Texture::GetUnorderedAccessView(uint32_t mips) const
+inline const DescriptorAllocation& Texture::GetUnorderedAccessView() const
 {
-	return _unorderedAccessView.GetDescriptorHandle(mips);
+	return _unorderedAccessView;
 }
 
 inline TextureType Texture::GetTextureType() const

--- a/Source/ChironEngine/Source/DataModels/DX12/Resource/VertexBuffer.cpp
+++ b/Source/ChironEngine/Source/DataModels/DX12/Resource/VertexBuffer.cpp
@@ -1,0 +1,20 @@
+#include "Pch.h"
+#include "VertexBuffer.h"
+
+VertexBuffer::VertexBuffer(const D3D12_RESOURCE_DESC& resourceDesc, size_t numVertices, size_t vertexStride, 
+	const std::wstring& name, const D3D12_CLEAR_VALUE* clearValue) : Resource(resourceDesc, name, clearValue), 
+	_numVertices(numVertices), _vertexStride(vertexStride)
+{
+	_vertexBufferView.BufferLocation = _resource->GetGPUVirtualAddress();
+	_vertexBufferView.SizeInBytes = static_cast<UINT>(_numVertices * _vertexStride);
+	_vertexBufferView.StrideInBytes = static_cast<UINT>(_vertexStride);
+}
+
+VertexBuffer::VertexBuffer(const VertexBuffer& copy) : Resource(copy), _numVertices(copy._numVertices),
+_vertexStride(copy._vertexStride), _vertexBufferView(copy._vertexBufferView)
+{
+}
+
+VertexBuffer::~VertexBuffer()
+{
+}

--- a/Source/ChironEngine/Source/DataModels/DX12/Resource/VertexBuffer.h
+++ b/Source/ChironEngine/Source/DataModels/DX12/Resource/VertexBuffer.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "Resource.h"
+
+class VertexBuffer : public Resource
+{
+public:
+	VertexBuffer() = delete;
+	VertexBuffer(const D3D12_RESOURCE_DESC& resourceDesc, size_t numVertices, size_t vertexStride, 
+		const std::wstring& name = L"",	const D3D12_CLEAR_VALUE* clearValue = nullptr);
+	VertexBuffer(const VertexBuffer& copy);
+
+	~VertexBuffer() override;
+
+	// ------------- GETTERS ----------------------
+
+	inline const D3D12_VERTEX_BUFFER_VIEW& GetVertexBufferView() const;
+
+private:
+	size_t _numVertices;
+	size_t _vertexStride;
+	D3D12_VERTEX_BUFFER_VIEW _vertexBufferView;
+};
+
+inline const D3D12_VERTEX_BUFFER_VIEW& VertexBuffer::GetVertexBufferView() const
+{
+	return _vertexBufferView;
+}

--- a/Source/ChironEngine/Source/DataModels/FileSystem/Importers/TextureImporter.cpp
+++ b/Source/ChironEngine/Source/DataModels/FileSystem/Importers/TextureImporter.cpp
@@ -138,7 +138,7 @@ void TextureImporter::Import(const char* filePath, std::shared_ptr<Texture> text
 
 	auto commandList = d3d12->GetCommandList(D3D12_COMMAND_LIST_TYPE_COPY);
 
-	commandList->CopyTextureSubresource(texture, 0, numSubresources, subresources.data());
+	commandList->UpdateBufferResource(texture, 0, numSubresources, subresources.data());
 
 	d3d12->ExecuteCommandList(commandList);
 

--- a/Source/ChironEngine/Source/DataModels/FileSystem/Importers/TextureImporter.cpp
+++ b/Source/ChironEngine/Source/DataModels/FileSystem/Importers/TextureImporter.cpp
@@ -27,7 +27,7 @@ void TextureImporter::Import(const char* filePath, std::shared_ptr<Texture> text
 
 	DirectX::TexMetadata md{};
 	DirectX::ScratchImage* imgResult = nullptr;
-	DirectX::ScratchImage img, flippedImg, dcmprsdImg; CHIRON_TODO("Flip Image");
+	DirectX::ScratchImage img, flippedImg, dcmprsdImg;
 
 	std::string extension = ModuleFileSystem::GetFileExtension(filePath);
 	if (extension == ".dds")
@@ -64,6 +64,31 @@ void TextureImporter::Import(const char* filePath, std::shared_ptr<Texture> text
 			LOG_ERROR("No suitable conversion for texture extension: {}", extension);
 		}
 	}
+
+	/*if (options.flipVertical && options.flipHorizontal)
+	{
+		if (!FAILED(DirectX::FlipRotate(img.GetImages(), img.GetImageCount(), img.GetMetadata(), 
+			DirectX::TEX_FR_FLAGS::TEX_FR_ROTATE180, flippedImg)))
+		{
+			img = std::move(flippedImg);
+		}
+	}
+	else if (options.flipVertical)
+	{
+		if (!FAILED(DirectX::FlipRotate(img.GetImages(), img.GetImageCount(), img.GetMetadata(),
+			DirectX::TEX_FR_FLAGS::TEX_FR_FLIP_VERTICAL, flippedImg)))
+		{
+			img = std::move(flippedImg);
+		}
+	}
+	else if (options.flipHorizontal)
+	{
+		if (!FAILED(DirectX::FlipRotate(img.GetImages(), img.GetImageCount(), img.GetMetadata(), 
+			DirectX::TEX_FR_FLAGS::TEX_FR_FLIP_HORIZONTAL, flippedImg)))
+		{
+			img = std::move(flippedImg);
+		}
+	}*/
 
 	CHIRON_TODO("temporary");
 	if (texture->GetTextureType() == TextureType::ALBEDO) 

--- a/Source/ChironEngine/Source/DataModels/Programs/GenerateMipsProgram.cpp
+++ b/Source/ChironEngine/Source/DataModels/Programs/GenerateMipsProgram.cpp
@@ -24,7 +24,7 @@ GenerateMipsProgram::GenerateMipsProgram(const std::string& name) : Program(name
         uavDesc.Texture2D.MipSlice = i;
         uavDesc.Texture2D.PlaneSlice = 0;
 
-        device->CreateUnorderedAccessView(nullptr, nullptr, &uavDesc, _descriptorAllocation.GetDescriptorHandle(i));
+        device->CreateUnorderedAccessView(nullptr, nullptr, &uavDesc, _descriptorAllocation.GetCPUDescriptorHandle(i));
     }
 }
 

--- a/Source/ChironEngine/Source/Modules/ModuleID3D12.cpp
+++ b/Source/ChironEngine/Source/Modules/ModuleID3D12.cpp
@@ -124,48 +124,6 @@ void ModuleID3D12::ResizeBuffers(unsigned newWidth, unsigned newHeight)
     CreateDepthStencil(newWidth, newHeight);
 }
 
-void ModuleID3D12::UpdateBufferResource(ComPtr<ID3D12GraphicsCommandList> commandList, 
-    ID3D12Resource** pDestinationResource, ID3D12Resource** pIntermediateResource, size_t numElements, size_t elementSize,
-    const void* bufferData, D3D12_RESOURCE_FLAGS flags)
-{
-    CHIRON_TODO("Delete");
-    size_t bufferSize = numElements * elementSize;
-
-    CD3DX12_HEAP_PROPERTIES heapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-    CD3DX12_RESOURCE_DESC resourceDesc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize, flags);
-
-    // Create a committed resource for the GPU resource in a default heap.
-    Chiron::Utils::ThrowIfFailed(_device->CreateCommittedResource(
-        &heapProperties,
-        D3D12_HEAP_FLAG_NONE, 
-        &resourceDesc,
-        D3D12_RESOURCE_STATE_COMMON, 
-        nullptr,
-        IID_PPV_ARGS(pDestinationResource)));
-
-    if (bufferData)
-    {
-        heapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-        resourceDesc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize);
-
-        // Create a commited resource in upload heap
-        Chiron::Utils::ThrowIfFailed(_device->CreateCommittedResource(
-            &heapProperties,
-            D3D12_HEAP_FLAG_NONE,
-            &resourceDesc,
-            D3D12_RESOURCE_STATE_GENERIC_READ,
-            nullptr,
-            IID_PPV_ARGS(pIntermediateResource)));
-        
-        D3D12_SUBRESOURCE_DATA subresourceData = {};
-        subresourceData.pData = bufferData;
-        subresourceData.RowPitch = bufferSize;
-        subresourceData.SlicePitch = subresourceData.RowPitch;
-        
-        UpdateSubresources(commandList.Get(), *pDestinationResource, *pIntermediateResource, 0, 0, 1, &subresourceData);
-    }
-}
-
 void ModuleID3D12::Flush()
 {
     _commandQueueDirect->Flush();

--- a/Source/ChironEngine/Source/Modules/ModuleID3D12.h
+++ b/Source/ChironEngine/Source/Modules/ModuleID3D12.h
@@ -121,6 +121,14 @@ private:
 
 inline ID3D12Device5* ModuleID3D12::GetDevice() const
 {
+#if DEBUG
+    HRESULT reason = _device->GetDeviceRemovedReason();
+
+    if (reason != S_OK)
+    {
+        assert(false);
+    }
+#endif
     return _device.Get();
 }
 

--- a/Source/ChironEngine/Source/Modules/ModuleID3D12.h
+++ b/Source/ChironEngine/Source/Modules/ModuleID3D12.h
@@ -27,13 +27,6 @@ public:
     void ToggleVSync();
     void ResizeBuffers(unsigned newWidth, unsigned newHeight);
 
-    // ------------- CREATORS ----------------------
-
-    // delete
-    void UpdateBufferResource(ComPtr<ID3D12GraphicsCommandList> commandList, ID3D12Resource** pDestinationResource,
-        ID3D12Resource** pIntermediateResource, size_t numElements, size_t elementSize, const void* bufferData,
-        D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE);
-
     // ------------- SYNCHRONIZATION ----------------------
 
     void SaveCurrentBufferFenceValue(const uint64_t& fenceValue);

--- a/Source/ChironEngine/Source/Modules/ModuleRender.cpp
+++ b/Source/ChironEngine/Source/Modules/ModuleRender.cpp
@@ -53,8 +53,8 @@ bool ModuleRender::Init()
 
     const UINT vertexBufferSize = sizeof(triangleVertices);
 
-    vertexBuffer = std::make_shared<VertexBuffer>(CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize), _countof(triangleVertices), sizeof(Vertex),
-        L"Triangle Vertex Buffer");
+    vertexBuffer = std::make_shared<VertexBuffer>(CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize), 
+        _countof(triangleVertices), sizeof(Vertex), L"Triangle Vertex Buffer");
 
     D3D12_SUBRESOURCE_DATA subresourceData = {};
     subresourceData.pData = triangleVertices;
@@ -68,8 +68,8 @@ bool ModuleRender::Init()
 
     const UINT indexBufferSize = sizeof(indexBufferData);
 
-    indexBuffer = std::make_shared<IndexBuffer>(CD3DX12_RESOURCE_DESC::Buffer(indexBufferSize), _countof(indexBufferData), DXGI_FORMAT_R32_UINT,
-        L"Triangle Index Buffer");
+    indexBuffer = std::make_shared<IndexBuffer>(CD3DX12_RESOURCE_DESC::Buffer(indexBufferSize), _countof(indexBufferData), 
+        DXGI_FORMAT_R32_UINT, L"Triangle Index Buffer");
 
     D3D12_SUBRESOURCE_DATA subresourceData2 = {};
     subresourceData2.pData = indexBufferData;
@@ -105,7 +105,8 @@ UpdateStatus ModuleRender::PreUpdate()
     // Clear Viewport
     FLOAT clearColor[] = { 0.4f, 0.4f, 0.4f, 1.0f }; // Set color
 
-    _drawCommandList->ClearRenderTargetView(d3d12->GetRenderTargetDescriptor(), clearColor, 0); // send the clear command into the list
+    // send the clear command into the list
+    _drawCommandList->ClearRenderTargetView(d3d12->GetRenderTargetDescriptor(), clearColor, 0);
 
     _drawCommandList->ClearDepthStencilView(d3d12->GetDepthStencilDescriptor(), D3D12_CLEAR_FLAG_DEPTH, 1.0, 0, 0);
 

--- a/Source/ChironEngine/Source/Modules/ModuleRender.h
+++ b/Source/ChironEngine/Source/Modules/ModuleRender.h
@@ -2,6 +2,8 @@
 #include "Module.h"
 
 class CommandList;
+class IndexBuffer;
+class VertexBuffer;
 class DebugDrawPass;
 
 struct Vertex
@@ -29,13 +31,9 @@ private:
     // Is used once its loaded into a Queue
     std::shared_ptr<CommandList> _drawCommandList;
 
-    ComPtr<ID3D12Resource> _vertexBuffer;
-    D3D12_VERTEX_BUFFER_VIEW _vertexBufferView;
-
-    ComPtr<ID3D12Resource> _indexBuffer;
-    D3D12_INDEX_BUFFER_VIEW _indexBufferView;
-
     std::unique_ptr<DebugDrawPass> _debugDraw;
+    std::shared_ptr<VertexBuffer> vertexBuffer;
+    std::shared_ptr<IndexBuffer> indexBuffer;
 
     D3D12_RECT _scissor;
 };

--- a/Source/ChironEngine/Source/Modules/ModuleRender.h
+++ b/Source/ChironEngine/Source/Modules/ModuleRender.h
@@ -3,13 +3,14 @@
 
 class CommandList;
 class IndexBuffer;
+class Texture;
 class VertexBuffer;
 class DebugDrawPass;
 
 struct Vertex
 {
     Vector3 position;
-    Vector4 color;
+    Vector2 texCoord;
 };
 
 class ModuleRender : public Module
@@ -25,13 +26,18 @@ public:
     bool CleanUp() override;
 
 private:
-    
-private:
+    struct ModelViewProjection
+    {
+        Matrix model;
+        Matrix view;
+        Matrix proj;
+    };
     // Indicate to the driver how a resource should be used in upcoming commands.
     // Is used once its loaded into a Queue
     std::shared_ptr<CommandList> _drawCommandList;
 
     std::unique_ptr<DebugDrawPass> _debugDraw;
+    std::shared_ptr<Texture> texture;
     std::shared_ptr<VertexBuffer> vertexBuffer;
     std::shared_ptr<IndexBuffer> indexBuffer;
 


### PR DESCRIPTION
- New Resource classes: `vertexBuffer` and `indexBuffer`.
- Use descriptors to load and apply textures.
- Adapt default shader and default program to the new feature.
- Fix and expand DX12 classes.
- Fix bugs and QOL.